### PR TITLE
Add web frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ You should see a link displayed in the CLI once the test has finished running. P
 
 ![Demo GIF](assets/demo.gif)
 
+## Web Frontend Example
+
+A simple React frontend is provided in the `frontend` directory. Start the API server with `python server.py` and run `npm install && npm run dev` inside `frontend` to try it out.
+
 <br />
 
 # Contributing

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DeepEval Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "deepeval-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.9",
+    "typescript": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+export default function App() {
+  const [input, setInput] = useState('');
+  const [expected, setExpected] = useState('');
+  const [actual, setActual] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch('/api/evaluate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input, expected_output: expected, actual_output: actual })
+      });
+      const data = await res.json();
+      setResult(JSON.stringify(data, null, 2));
+    } catch (err) {
+      setResult('Error running evaluation');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>DeepEval Playground</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <textarea placeholder="Input" value={input} onChange={(e) => setInput(e.target.value)} />
+        </div>
+        <div>
+          <textarea placeholder="Expected Output" value={expected} onChange={(e) => setExpected(e.target.value)} />
+        </div>
+        <div>
+          <textarea placeholder="Actual Output" value={actual} onChange={(e) => setActual(e.target.value)} />
+        </div>
+        <button type="submit" disabled={loading}>{loading ? 'Evaluating...' : 'Evaluate'}</button>
+      </form>
+      {result && <pre>{result}</pre>}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+});

--- a/server.py
+++ b/server.py
@@ -1,0 +1,37 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+
+app = FastAPI()
+
+class EvalRequest(BaseModel):
+    input: str
+    expected_output: str
+    actual_output: str
+
+@app.post("/api/evaluate")
+def evaluate(req: EvalRequest):
+    metric = GEval(
+        name="Correctness",
+        criteria="Determine if the 'actual_output' is correct based on the 'expected_output'.",
+        evaluation_params=[
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ],
+    )
+    test_case = LLMTestCase(
+        input=req.input,
+        actual_output=req.actual_output,
+        expected_output=req.expected_output,
+    )
+    metric.measure(test_case)
+    return {
+        "score": metric.score,
+        "success": metric.success,
+        "reason": metric.reason,
+    }
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- create minimal React app in `frontend`
- add FastAPI-based evaluation API
- document how to launch the web interface

## Testing
- `pytest -k test_answer_relevancy.py::test_float` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6868f6dbb6088325829c2d5db682feb6