### PR TITLE
Improve web frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ You should see a link displayed in the CLI once the test has finished running. P
 
 ![Demo GIF](assets/demo.gif)
 
+## Web Frontend Example
+
+A simple React frontend is provided in the `frontend` directory. Start the API server with `python server.py` and run `npm install && npm run dev` inside `frontend` to try it out.
+
 <br />
 
 # Contributing

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DeepEval Frontend</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "deepeval-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.9",
+    "typescript": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+
+interface TestCase {
+  input: string;
+  expected_output: string;
+  actual_output: string;
+}
+
+export default function App() {
+  const [metric, setMetric] = useState('correctness');
+  const [tests, setTests] = useState<TestCase[]>([
+    { input: '', expected_output: '', actual_output: '' }
+  ]);
+  const [results, setResults] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  const updateTest = (index: number, field: keyof TestCase, value: string) => {
+    setTests(t => {
+      const copy = [...t];
+      copy[index] = { ...copy[index], [field]: value };
+      return copy;
+    });
+  };
+
+  const addTest = () => {
+    setTests(t => [...t, { input: '', expected_output: '', actual_output: '' }]);
+  };
+
+  const removeTest = (i: number) => {
+    setTests(t => t.filter((_, idx) => idx !== i));
+  };
+
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    file.text().then(text => {
+      try {
+        const data = JSON.parse(text);
+        if (Array.isArray(data)) {
+          setTests(data);
+        }
+      } catch (err) {
+        console.error('Invalid file');
+      }
+    });
+  };
+
+  const download = () => {
+    const blob = new Blob([JSON.stringify(tests, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'tests.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch('/api/evaluate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ metric, tests })
+      });
+      const data = await res.json();
+      setResults(data);
+    } catch (err) {
+      setResults({ error: 'Failed to evaluate' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold mb-4">DeepEval Playground</h1>
+      <div className="flex items-center space-x-4">
+        <label className="block text-sm font-medium">Metric</label>
+        <select
+          value={metric}
+          onChange={e => setMetric(e.target.value)}
+          className="border px-2 py-1 rounded"
+        >
+          <option value="correctness">Correctness</option>
+          <option value="answer_relevancy">Answer Relevancy</option>
+        </select>
+        <input type="file" accept="application/json" onChange={handleUpload} className="text-sm" />
+        <button type="button" onClick={download} className="px-2 py-1 bg-gray-200 rounded">Download</button>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {tests.map((t, idx) => (
+          <div key={idx} className="border p-4 rounded space-y-2">
+            <div className="flex justify-between">
+              <span className="font-medium">Test {idx + 1}</span>
+              {tests.length > 1 && (
+                <button type="button" onClick={() => removeTest(idx)} className="text-red-600">Remove</button>
+              )}
+            </div>
+            <textarea
+              className="w-full border p-2 rounded"
+              placeholder="Input"
+              value={t.input}
+              onChange={e => updateTest(idx, 'input', e.target.value)}
+            />
+            <textarea
+              className="w-full border p-2 rounded"
+              placeholder="Expected Output"
+              value={t.expected_output}
+              onChange={e => updateTest(idx, 'expected_output', e.target.value)}
+            />
+            <textarea
+              className="w-full border p-2 rounded"
+              placeholder="Actual Output"
+              value={t.actual_output}
+              onChange={e => updateTest(idx, 'actual_output', e.target.value)}
+            />
+          </div>
+        ))}
+        <button type="button" onClick={addTest} className="px-3 py-1 bg-blue-500 text-white rounded">
+          Add Test
+        </button>
+        <div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="px-4 py-2 bg-green-600 text-white rounded mt-2"
+          >
+            {loading ? 'Evaluating...' : 'Run Evaluation'}
+          </button>
+        </div>
+      </form>
+      {results && <pre className="bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(results, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+});

--- a/server.py
+++ b/server.py
@@ -1,0 +1,50 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+
+from deepeval.metrics import GEval, AnswerRelevancyMetric
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+
+app = FastAPI()
+
+class TestCase(BaseModel):
+    input: str
+    expected_output: str
+    actual_output: str
+
+
+class EvalRequest(BaseModel):
+    metric: str = "correctness"
+    tests: List[TestCase]
+
+@app.post("/api/evaluate")
+def evaluate(req: EvalRequest):
+    results = []
+    for test in req.tests:
+        if req.metric == "answer_relevancy":
+            metric = AnswerRelevancyMetric()
+        else:
+            metric = GEval(
+                name="Correctness",
+                criteria="Determine if the 'actual_output' is correct based on the 'expected_output'.",
+                evaluation_params=[
+                    LLMTestCaseParams.ACTUAL_OUTPUT,
+                    LLMTestCaseParams.EXPECTED_OUTPUT,
+                ],
+            )
+        test_case = LLMTestCase(
+            input=test.input,
+            actual_output=test.actual_output,
+            expected_output=test.expected_output,
+        )
+        metric.measure(test_case)
+        results.append({
+            "score": metric.score,
+            "success": metric.success,
+            "reason": metric.reason,
+        })
+    return {"results": results}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- let users pick metrics and run batches
- allow uploading/downloading test cases
- style frontend with tailwind.css

## Testing
- `pytest -k test_answer_relevancy.py::test_float` *(fails: ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6868f6dbb6088325829c2d5db682feb6